### PR TITLE
Stripeアカウント作成後の遷移場所を元のフォーム画面にする

### DIFF
--- a/src/app/editor/editor/editor.component.html
+++ b/src/app/editor/editor/editor.component.html
@@ -10,6 +10,16 @@
 
     <mat-divider></mat-divider>
 
+    <div class="notice form-grid">
+      <div class="spacer"></div>
+      <div class="notice__content">
+        <span class="notice__mark">※</span>
+        <p class="notice__text">
+          販売アカウントの設定・変更をされる場合はフォーム記入前に行ってください。アカウント設定後、フォーム記入内容はリセットされます。
+        </p>
+      </div>
+    </div>
+
     <form [formGroup]="form" (ngSubmit)="submit(user.uid)" class="form-group">
       <div class="form-grid">
         <p class="form-grid__label">イベント名</p>

--- a/src/app/editor/editor/editor.component.scss
+++ b/src/app/editor/editor/editor.component.scss
@@ -18,6 +18,21 @@ mat-form-field {
   }
 }
 
+.notice {
+  &__content {
+    display: grid;
+    grid-template-columns: 14px 1fr;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  &__mark {
+    line-height: 1;
+  }
+  &__text {
+    font-size: 11px;
+  }
+}
+
 .form-group {
   display: grid;
   grid-template-columns: 1fr;

--- a/src/app/services/connected-account.service.ts
+++ b/src/app/services/connected-account.service.ts
@@ -19,8 +19,9 @@ export class ConnectedAccountService {
   ) {}
 
   async createStripeConnectedAccount(): Promise<void> {
+    const redirectURL = location.href;
     const callable = this.fns.httpsCallable('getStripeConnectedAccountState');
-    const state = await callable({}).toPromise();
+    const state = await callable({ redirectURL: redirectURL }).toPromise();
     const url = 'https://connect.stripe.com/express/oauth/authorize';
     location.href = `${url}?client_id=${environment.stripe.clientId}&state=${state}&suggested_capabilities[]=transfers`;
   }


### PR DESCRIPTION
Fixes #187

### 作業内容

Stripeアカウント作成後の遷移場所を元のフォーム画面にする